### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ your store. Now pass the `myReducer` just like you would a function with a switc
 
 ```javascript
 import { createReducer } from 'ngrx-actions';
-export const myReducer = function(state, action) { return createReducer(MyStore)(state, action); }
+export function myReducer(state, action) { return createReducer(MyStore)(state, action); }
 ```
 
 In the above example, I return a function that returns my `createReducer`. This is because AoT


### PR DESCRIPTION
Exporting a `const` still produced the same AOT error for me (I'm running Angular 5.2.3, Angular CLI 1.6.7, and TypeScript 2.4.2), but switching to exporting a `function` eliminated that error.