### PR TITLE
Preventing modifications of the existing state

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,13 @@ export class MyStore {
 }
 ```
 
-You may notice, I don't return the state. Thats because if it doesn't see
-a state returned from the action it inspects whether the state was an
-object or array and automatically creates a new instance for you. If you are
-mutating deeply nested properties, you still need to deal with those yourself.
+You may notice, I don't always return the state. That's because if you're relying on the library
+to create your reducer (using `createReducer` - more on that below), it would inspect
+whether the state was an object or an array, automatically create a new state instance 
+for you and pass it to the function with @Action decorator. So you're not modifying an
+existing state in the function, which would be a bad practice - instead you're operating
+on a reference to a newly created instance of the state, which is then passed down the
+ngrx pipeline for you, behind the scenes.
 
 You can still return the state yourself and it won't mess with it. This is helpful
 for if the state didn't change or you have some complex logic going on. This can be

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,7 +1,7 @@
 import { Action } from '@ngrx/store';
 import { NGRX_ACTIONS_META, StoreMetadata } from './internals';
 import { NgrxSelect } from './select';
-import { take, materialize } from 'rxjs/operators';
+import { materialize } from 'rxjs/operators';
 
 export function createReducer<TState = any>(
   store:
@@ -23,15 +23,12 @@ export function createReducer<TState = any>(
   return function(state: any = initialState, action: Action) {
     const actionMeta = actions[action.type];
     if (actionMeta) {
-      const result = instance[actionMeta.fn](state, action);
+      const newStateInstance = Array.isArray(state) ? [...state] : { ...state };
+      let result = instance[actionMeta.fn](newStateInstance, action);
       if (result === undefined) {
-        if (Array.isArray(state)) {
-          return [...state];
-        } else {
-          return { ...state };
-        }
+        result = newStateInstance;
       }
-      state = result;
+      store = result;
     }
 
     const effectMeta = effects[action.type];


### PR DESCRIPTION
Many people use ngrx-store-freeze, which deep-freezes the state so that one didn't modify an existing state during development. If that's used, applying changes to the state object passed to the `@Action`-decorated function (e.g. `state.loading = true`) will result in `TypeError: Cannot assign to read only property 'loading' of object '[object Object]'`. I tested that with these changes the error doesn't occur, as the modification would then be applied to the new state instance.