### PR TITLE
Add State to Store

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -21,10 +21,17 @@ export function createReducer<TState = any>(
   const instance = isInstance ? store : new store();
   const { initialState, actions, effects } = klass[NGRX_ACTIONS_META] as StoreMetadata;
 
-  return function(state: any = initialState, action: Action) {
+  return function (state: any = initialState, action: Action) {
+    const instanceHasState = instance.hasOwnProperty('state');
+    if (instanceHasState) {
+      instance.state = state;
+    }
+
     const actionMeta = actions[action.type];
     if (actionMeta) {
-      const result = instance[actionMeta.fn](state, action);
+      const result = instanceHasState ?
+        instance[actionMeta.fn](action) :
+        instance[actionMeta.fn](state, action);
       if (result === undefined) {
         if (Array.isArray(state)) {
           return [...state];

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -1,7 +1,7 @@
 export { NgrxActionsModule } from './module';
 export { Action } from './action';
 export { ofAction } from './of-action';
-export { Store } from './store';
+export { Store, BaseStore } from './store';
 export { Select, NgrxSelect } from './select';
 export { createReducer } from './factory';
 export { Effect } from './effect';

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,3 +8,7 @@ export function Store(initialState: any = {}) {
     meta.initialState = initialState;
   };
 }
+
+export abstract class BaseStore<TState = any> {
+  state: TState = {} as TState;
+}


### PR DESCRIPTION
Hello, while writing reducers each action within one store takes the state of the same type as an input. It could be easily omitted by moving the state to the base class. 

It would transform this:
```ts
@Store<MyState>({ ... })
export class MyStore {
  @Action(Action1)
  action1(state: MyState, action: Action1) {
    return { ...state, action.payload };
  }
  // ...
}
```
into that:
```ts
@Store<MyState>({ ... })
export class MyStore extends BaseStore<MyState> {
  @Action(Action1)
  action1(action: Action1) {
    return { ...this.state, action.payload };
  }
  // ...
}
```

The change that I made is very simple and doesn't conflict with the existing solution. The only downside is that it does not work for effects placed in the store because of their asynchronous nature.

What do you think about my approach? I feel like it would help to reduce what is left off so much hated boilerplate.